### PR TITLE
Expose all part sources

### DIFF
--- a/partmaster.go
+++ b/partmaster.go
@@ -33,8 +33,12 @@ func (p partmaster) String() string {
 	return result
 }
 
-// findPart returns part with highest priority
-func (p *partmaster) findPart(pn ipn) (*partmasterLine, error) {
+// findPartSources returns all matching parts for a given IPN sorted by priority.
+// Missing description, footprint, and value fields are populated from the
+// highest priority part so every returned entry has the same core data. This
+// enables callers to access an arbitrary number of sources for a single part
+// number.
+func (p *partmaster) findPartSources(pn ipn) ([]*partmasterLine, error) {
 	found := []*partmasterLine{}
 	for _, l := range *p {
 		if l.IPN == pn {
@@ -42,28 +46,51 @@ func (p *partmaster) findPart(pn ipn) (*partmasterLine, error) {
 		}
 	}
 
-	if len(found) <= 0 {
+	if len(found) == 0 {
 		return nil, fmt.Errorf("Part not found")
 	}
 
 	sort.Sort(byPriority(found))
 
+	base := found[0]
 	if len(found) > 1 {
-		// fill in blank fields with values from other items
+		// fill in blank fields on the highest priority entry
 		for i := 1; i < len(found); i++ {
-			if found[0].Description == "" && found[i].Description != "" {
-				found[0].Description = found[i].Description
+			if base.Description == "" && found[i].Description != "" {
+				base.Description = found[i].Description
 			}
-			if found[0].Footprint == "" && found[i].Footprint != "" {
-				found[0].Footprint = found[i].Footprint
+			if base.Footprint == "" && found[i].Footprint != "" {
+				base.Footprint = found[i].Footprint
 			}
-			if found[0].Value == "" && found[i].Value != "" {
-				found[0].Value = found[i].Value
+			if base.Value == "" && found[i].Value != "" {
+				base.Value = found[i].Value
 			}
 		}
 	}
 
-	return found[0], nil
+	// propagate common fields to all returned parts
+	for _, f := range found {
+		if f.Description == "" {
+			f.Description = base.Description
+		}
+		if f.Footprint == "" {
+			f.Footprint = base.Footprint
+		}
+		if f.Value == "" {
+			f.Value = base.Value
+		}
+	}
+
+	return found, nil
+}
+
+// findPart returns part with highest priority
+func (p *partmaster) findPart(pn ipn) (*partmasterLine, error) {
+	parts, err := p.findPartSources(pn)
+	if err != nil {
+		return nil, err
+	}
+	return parts[0], nil
 }
 
 // type for sorting

--- a/partmaster_test.go
+++ b/partmaster_test.go
@@ -43,3 +43,34 @@ func TestPartmaster(t *testing.T) {
 		t.Fatalf("Error finding part CAP-001-1002: %v", err)
 	}
 }
+
+func TestPartmasterFindPartSources(t *testing.T) {
+	initCSV()
+	pm := partmaster{}
+	err := gocsv.UnmarshalBytes([]byte(pmIn), &pm)
+	if err != nil {
+		t.Fatalf("Error parsing pmIn: %v", err)
+	}
+
+	parts, err := pm.findPartSources("CAP-001-1001")
+	if err != nil {
+		t.Fatalf("Error finding sources for CAP-001-1001: %v", err)
+	}
+
+	if len(parts) != 2 {
+		t.Fatalf("Expected 2 sources for CAP-001-1001, got %v", len(parts))
+	}
+
+	if parts[0].MPN != "abc2322" || parts[1].MPN != "10045" {
+		t.Errorf("Sources not sorted by priority: got %v then %v", parts[0].MPN, parts[1].MPN)
+	}
+
+	for i, p := range parts {
+		if p.Description != "superduper cap" {
+			t.Errorf("Wrong description for source %v: %v", i, p.Description)
+		}
+		if p.Value != "10k" {
+			t.Errorf("Wrong value for source %v: %v", i, p.Value)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- expose `findPartSources` to return every matching source for an IPN
- use new helper in `findPart` and propagate common data
- test that multiple sources are returned and sorted by priority

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6895249002dc832697e571f16dd76663