### PR TITLE
docs: add Docker deployment instructions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+# syntax=docker/dockerfile:1
+
+FROM golang:1.21 AS build
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 go build -o /gitplm
+
+FROM alpine:3.18
+RUN adduser -D appuser
+USER appuser
+WORKDIR /workspace
+COPY --from=build /gitplm /usr/local/bin/gitplm
+ENTRYPOINT ["gitplm"]

--- a/README.md
+++ b/README.md
@@ -54,6 +54,18 @@ or
 
 - clone the Git repo and run: `go run .`
 
+### Docker deployment
+
+You can build and run GitPLM in a container:
+
+```bash
+docker build -t gitplm .
+docker run --rm -v "$(pwd)":/workspace gitplm -release PCB-019-0001
+```
+
+Mount your project directory into the container and adjust the `-release`
+argument for your use case.
+
 ## Usage
 
 Type `gitplm` from a shell to see commandline options:


### PR DESCRIPTION
## Summary
- document how to build and run gitplm with Docker
- add Dockerfile for container builds

## Testing
- `go test ./...`
- `docker build -t gitplm-test .` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_689523ed8bc0832688e2b425c453310d