### PR TITLE
Add Docker deployment support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+.git
+*.md
+*.png
+*.svg
+example/
+assets/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+# syntax=docker/dockerfile:1
+
+FROM golang:1.24 AS builder
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+ARG TARGETOS TARGETARCH
+RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -o /gitplm
+
+FROM alpine:3.19
+RUN apk --no-cache add ca-certificates
+WORKDIR /app
+COPY --from=builder /gitplm ./gitplm
+ENTRYPOINT ["./gitplm"]

--- a/README.md
+++ b/README.md
@@ -54,6 +54,18 @@ or
 
 - clone the Git repo and run: `go run .`
 
+### Docker
+
+Build a container image and run GitPLM with Docker Desktop:
+
+```bash
+docker build -t gitplm .
+# run the tool from your project directory
+docker run --rm -v "$(pwd)":/workspace -w /workspace gitplm -version
+```
+
+Use the command line flags as needed when invoking the container.
+
 ## Usage
 
 Type `gitplm` from a shell to see commandline options:


### PR DESCRIPTION
## Summary
- containerize gitplm with a multi-stage Dockerfile for Docker Desktop
- add .dockerignore to reduce build context
- document Docker build and run steps in README

## Testing
- `go test ./...`
- `go vet ./...`
- `docker build -t gitplm-test .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689523bfe11c832681b107733c608461