### PR TITLE
Build frontend and fix Docker entrypoint

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,3 +4,5 @@
 *.svg
 example/
 assets/
+frontend/node_modules
+frontend/dist

--- a/README.md
+++ b/README.md
@@ -56,15 +56,19 @@ or
 
 ### Docker
 
-Build a container image and run GitPLM with Docker Desktop:
+Build a container image and run GitPLM with Docker:
 
 ```bash
 docker build -t gitplm .
-# run the tool from your project directory
 docker run --rm -v "$(pwd)":/workspace -w /workspace gitplm -version
 ```
 
-Use the command line flags as needed when invoking the container.
+Use the command line flags as needed when invoking the container. To start the
+HTTP server and serve the frontend, expose port 8080:
+
+```bash
+docker run --rm -p 8080:8080 gitplm -http -pmDir /workspace
+```
 
 ## Usage
 


### PR DESCRIPTION
## Summary
- build React frontend during Docker image creation and include it in the runtime image
- serve built frontend from the Go HTTP server
- use absolute path for the Docker entrypoint and expose port 8080
- document how to run the container without shell comment issues

## Testing
- `go test ./...`
- `cd frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_689581048f40832699a75b60f7dff9e8