### PR TITLE
fix(frontend): handle malformed parts response

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -19,9 +19,15 @@ function App() {
   const loadParts = (id) => {
     setSelectedCategory(id);
     axios.get(`${API_BASE}/v1/parts/category/${id}.json`).then(res => {
-      setParts(res.data);
+      if (Array.isArray(res.data)) {
+        setParts(res.data);
+      } else {
+        console.error('Unexpected parts response', res.data);
+        setParts([]);
+      }
     }).catch(err => {
       console.error('Failed to load parts', err);
+      setParts([]);
     });
   };
 

--- a/frontend/src/App.test.jsx
+++ b/frontend/src/App.test.jsx
@@ -1,11 +1,29 @@
-import { render, screen } from '@testing-library/react';
-import { expect, test } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { expect, test, vi, beforeEach } from 'vitest';
 import * as matchers from '@testing-library/jest-dom/matchers';
 import App from './App';
+import axios from 'axios';
 
 expect.extend(matchers);
 
+vi.mock('axios');
+
+beforeEach(() => {
+  axios.get.mockReset();
+});
+
 test('renders header', () => {
+  axios.get.mockResolvedValue({ data: [] });
   render(<App />);
   expect(screen.getByText(/GitPLM/i)).toBeInTheDocument();
+});
+
+test('handles non-array parts response', async () => {
+  axios.get.mockResolvedValueOnce({ data: [{ id: 'RES', name: 'Resistors' }] });
+  axios.get.mockResolvedValueOnce({ data: { error: 'oops' } });
+  render(<App />);
+  fireEvent.click(await screen.findByText('RES - Resistors'));
+  await waitFor(() => {
+    expect(screen.getByText('Parts for RES')).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## Summary
- guard against malformed parts response that caused UI crash
- test clicking RES with invalid data

## Testing
- `npm test`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6895874f9ca4832697181ad81575accd