### PR TITLE
feat(frontend): add part creation

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -7,6 +7,8 @@ function App() {
   const [categories, setCategories] = useState([]);
   const [parts, setParts] = useState([]);
   const [selectedCategory, setSelectedCategory] = useState(null);
+  const [newPartId, setNewPartId] = useState('');
+  const [newPartName, setNewPartName] = useState('');
 
   useEffect(() => {
     axios.get(`${API_BASE}/v1/categories.json`).then(res => {
@@ -22,6 +24,21 @@ function App() {
       setParts(res.data);
     }).catch(err => {
       console.error('Failed to load parts', err);
+    });
+  };
+
+  const createPart = () => {
+    if (!selectedCategory || !newPartId) return;
+    axios.post(`${API_BASE}/v1/parts.json`, {
+      id: newPartId,
+      name: newPartName,
+      category: selectedCategory,
+    }).then(() => {
+      setNewPartId('');
+      setNewPartName('');
+      loadParts(selectedCategory);
+    }).catch(err => {
+      console.error('Failed to create part', err);
     });
   };
 
@@ -48,6 +65,22 @@ function App() {
               <li key={part.id}>{part.id}{part.name ? ` - ${part.name}` : ''}</li>
             ))}
           </ul>
+          {selectedCategory && (
+            <div style={{ marginTop: '1rem' }}>
+              <h3>Create Part</h3>
+              <input
+                placeholder="Part ID"
+                value={newPartId}
+                onChange={e => setNewPartId(e.target.value)}
+              />
+              <input
+                placeholder="Part Name"
+                value={newPartName}
+                onChange={e => setNewPartName(e.target.value)}
+              />
+              <button onClick={createPart}>Create Part</button>
+            </div>
+          )}
         </div>
       </div>
     </div>

--- a/frontend/src/App.test.jsx
+++ b/frontend/src/App.test.jsx
@@ -1,11 +1,47 @@
-import { render, screen } from '@testing-library/react';
-import { expect, test } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { expect, test, vi } from 'vitest';
 import * as matchers from '@testing-library/jest-dom/matchers';
 import App from './App';
+import axios from 'axios';
+
+vi.mock('axios', () => ({
+  default: {
+    get: vi.fn(() => Promise.resolve({ data: [] })),
+    post: vi.fn(() => Promise.resolve({})),
+  },
+}));
 
 expect.extend(matchers);
 
 test('renders header', () => {
   render(<App />);
   expect(screen.getByText(/GitPLM/i)).toBeInTheDocument();
+});
+
+test('allows creating a part', async () => {
+  axios.get
+    .mockResolvedValueOnce({ data: [{ id: 'RES', name: 'Resistors' }] })
+    .mockResolvedValueOnce({ data: [] })
+    .mockResolvedValueOnce({ data: [{ id: 'RES-1234', name: 'My Resistor' }] });
+  axios.post.mockResolvedValueOnce({});
+
+  render(<App />);
+
+  const categoryButton = await screen.findByRole('button', { name: /RES - Resistors/ });
+  fireEvent.click(categoryButton);
+
+  const idInput = await screen.findByPlaceholderText('Part ID');
+  fireEvent.change(idInput, { target: { value: 'RES-1234' } });
+
+  const nameInput = screen.getByPlaceholderText('Part Name');
+  fireEvent.change(nameInput, { target: { value: 'My Resistor' } });
+
+  fireEvent.click(screen.getByRole('button', { name: 'Create Part' }));
+
+  await waitFor(() => {
+    expect(axios.post).toHaveBeenCalledWith(
+      'http://localhost:8080/v1/parts.json',
+      { id: 'RES-1234', name: 'My Resistor', category: 'RES' }
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- enable creating parts via POST API
- add frontend test for part creation flow

## Testing
- `npm test --prefix frontend`


------
https://chatgpt.com/codex/tasks/task_e_6895876bb1108326b4d81d043c1696c2