### PR TITLE
Handle missing CSVs by generating blank partmaster

### DIFF
--- a/partmaster.go
+++ b/partmaster.go
@@ -109,6 +109,14 @@ func loadPartmasterFromDir(dir string) (partmaster, error) {
 		return pm, fmt.Errorf("error finding CSV files in directory %s: %v", dir, err)
 	}
 
+	if len(files) == 0 {
+		_, err := createBlankPartmasterCSV(dir)
+		if err != nil {
+			return pm, err
+		}
+		files = []string{filepath.Join(dir, "partmaster.csv")}
+	}
+
 	for _, file := range files {
 		var temp partmaster
 		err := loadCSV(file, &temp)


### PR DESCRIPTION
## Summary
- Generate a blank `partmaster.csv` with standard headers when no CSV files are present
- Ensure partmaster loading creates the empty file so the app can run without examples

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6895877e68e88326b35fb70f453b1319