### PR TITLE
Avoid repeated category reload in parts list

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -17,7 +17,11 @@ function App() {
   }, []);
 
   const loadParts = (id) => {
+    if (id === selectedCategory) {
+      return;
+    }
     setSelectedCategory(id);
+    setParts([]);
     axios.get(`${API_BASE}/v1/parts/category/${id}.json`).then(res => {
       setParts(res.data);
     }).catch(err => {


### PR DESCRIPTION
## Summary
- Prevent duplicate part entries by ignoring repeated category clicks
- Clear parts list before fetching new category data

## Testing
- `npm test --prefix frontend`


------
https://chatgpt.com/codex/tasks/task_e_6895882390248326b23edf61f35ca9a7