### PR TITLE
Add part editing screen and revision controls

### DIFF
--- a/csv_data.go
+++ b/csv_data.go
@@ -40,7 +40,7 @@ func loadCSVRaw(filePath string) (*CSVFile, error) {
 	if err != nil {
 		return nil, fmt.Errorf("error reading headers from %s: %v", filePath, err)
 	}
-	
+
 	// Trim whitespace from headers
 	for i := range headers {
 		headers[i] = strings.TrimSpace(headers[i])
@@ -115,6 +115,36 @@ func (c *CSVFileCollection) GetCombinedPartmaster() (partmaster, error) {
 	}
 
 	return pm, nil
+}
+
+// saveCSVFile writes a CSVFile back to disk, preserving headers and rows
+func saveCSVFile(file *CSVFile) error {
+	f, err := os.Create(file.Path)
+	if err != nil {
+		return fmt.Errorf("error opening file %s: %w", file.Path, err)
+	}
+	defer f.Close()
+
+	w := csv.NewWriter(f)
+	w.Comma = ','
+
+	if err := w.Write(file.Headers); err != nil {
+		return fmt.Errorf("error writing headers: %w", err)
+	}
+
+	for _, row := range file.Rows {
+		if len(row) < len(file.Headers) {
+			padded := make([]string, len(file.Headers))
+			copy(padded, row)
+			row = padded
+		}
+		if err := w.Write(row); err != nil {
+			return fmt.Errorf("error writing row: %w", err)
+		}
+	}
+
+	w.Flush()
+	return w.Error()
 }
 
 // parseFileAsPartmaster attempts to parse a CSV file as partmaster format

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -7,49 +7,173 @@ function App() {
   const [categories, setCategories] = useState([]);
   const [parts, setParts] = useState([]);
   const [selectedCategory, setSelectedCategory] = useState(null);
+  const [selectedPart, setSelectedPart] = useState(null);
+  const [description, setDescription] = useState('');
+  const [sources, setSources] = useState([{ manufacturer: '', mpn: '' }]);
+  const [revision, setRevision] = useState('');
 
   useEffect(() => {
-    axios.get(`${API_BASE}/v1/categories.json`).then(res => {
-      setCategories(res.data);
-    }).catch(err => {
-      console.error('Failed to load categories', err);
-    });
+    axios
+      .get(`${API_BASE}/v1/categories.json`)
+      .then(res => {
+        setCategories(res.data);
+      })
+      .catch(err => {
+        console.error('Failed to load categories', err);
+      });
   }, []);
 
-  const loadParts = (id) => {
+  const loadParts = id => {
     setSelectedCategory(id);
-    axios.get(`${API_BASE}/v1/parts/category/${id}.json`).then(res => {
-      setParts(res.data);
-    }).catch(err => {
-      console.error('Failed to load parts', err);
-    });
+    axios
+      .get(`${API_BASE}/v1/parts/category/${id}.json`)
+      .then(res => {
+        setParts(res.data);
+      })
+      .catch(err => {
+        console.error('Failed to load parts', err);
+      });
+  };
+
+  const loadPartDetail = id => {
+    axios
+      .get(`${API_BASE}/v1/parts/${id}.json`)
+      .then(res => {
+        const detail = res.data;
+        setSelectedPart(detail);
+        setDescription(detail.fields?.Description?.value || '');
+        const srcs = [];
+        let idx = 1;
+        while (true) {
+          const mKey = idx === 1 ? 'Manufacturer' : `Manufacturer${idx}`;
+          const pKey = idx === 1 ? 'MPN' : `MPN${idx}`;
+          const m = detail.fields?.[mKey]?.value;
+          const p = detail.fields?.[pKey]?.value;
+          if (!m && !p) break;
+          srcs.push({ manufacturer: m || '', mpn: p || '' });
+          idx++;
+        }
+        if (srcs.length === 0) srcs.push({ manufacturer: '', mpn: '' });
+        setSources(srcs);
+        setRevision(detail.revision || '');
+      })
+      .catch(err => {
+        console.error('Failed to load part', err);
+      });
+  };
+
+  const updateSource = (idx, field, value) => {
+    const newSources = sources.map((s, i) =>
+      i === idx ? { ...s, [field]: value } : s
+    );
+    setSources(newSources);
+  };
+
+  const addSource = () => {
+    setSources([...sources, { manufacturer: '', mpn: '' }]);
+  };
+
+  const savePart = () => {
+    if (!selectedPart) return;
+    axios
+      .put(`${API_BASE}/v1/parts/${selectedPart.id}.json`, {
+        description,
+        sources,
+      })
+      .then(res => {
+        setSelectedPart(res.data);
+        loadParts(selectedCategory);
+      })
+      .catch(err => console.error('Failed to save part', err));
+  };
+
+  const startRevision = () => {
+    if (!selectedPart) return;
+    axios
+      .post(`${API_BASE}/v1/parts/${selectedPart.id}/revision`)
+      .then(res => {
+        loadParts(selectedCategory);
+        loadPartDetail(res.data.id);
+      })
+      .catch(err => console.error('Failed to start revision', err));
   };
 
   return (
     <div style={{ padding: '1rem', fontFamily: 'Arial, sans-serif' }}>
       <h1>GitPLM</h1>
-      <div style={{ display: 'flex', gap: '2rem' }}>
+      {selectedPart ? (
         <div>
-          <h2>Categories</h2>
-          <ul>
-            {categories.map(cat => (
-              <li key={cat.id}>
-                <button onClick={() => loadParts(cat.id)}>
-                  {cat.id} - {cat.name}
-                </button>
-              </li>
-            ))}
-          </ul>
+          <h2>Edit Part {selectedPart.id}</h2>
+          <p>Revision: {revision}</p>
+          <div>
+            <label>
+              Description
+              <input
+                value={description}
+                onChange={e => setDescription(e.target.value)}
+                style={{ marginLeft: '0.5rem' }}
+              />
+            </label>
+          </div>
+          <h3>Sources</h3>
+          {sources.map((src, idx) => (
+            <div key={idx} style={{ marginBottom: '0.5rem' }}>
+              <input
+                placeholder="Manufacturer"
+                value={src.manufacturer}
+                onChange={e => updateSource(idx, 'manufacturer', e.target.value)}
+              />
+              <input
+                placeholder="MPN"
+                value={src.mpn}
+                onChange={e => updateSource(idx, 'mpn', e.target.value)}
+                style={{ marginLeft: '0.5rem' }}
+              />
+            </div>
+          ))}
+          <button onClick={addSource}>Add Source</button>
+          <div style={{ marginTop: '1rem' }}>
+            <button onClick={savePart}>Save</button>
+            <button onClick={startRevision} style={{ marginLeft: '0.5rem' }}>
+              Start New Revision
+            </button>
+            <button
+              onClick={() => setSelectedPart(null)}
+              style={{ marginLeft: '0.5rem' }}
+            >
+              Back
+            </button>
+          </div>
         </div>
-        <div>
-          <h2>Parts {selectedCategory ? `for ${selectedCategory}` : ''}</h2>
-          <ul>
-            {parts.map(part => (
-              <li key={part.id}>{part.id}{part.name ? ` - ${part.name}` : ''}</li>
-            ))}
-          </ul>
+      ) : (
+        <div style={{ display: 'flex', gap: '2rem' }}>
+          <div>
+            <h2>Categories</h2>
+            <ul>
+              {categories.map(cat => (
+                <li key={cat.id}>
+                  <button onClick={() => loadParts(cat.id)}>
+                    {cat.id} - {cat.name}
+                  </button>
+                </li>
+              ))}
+            </ul>
+          </div>
+          <div>
+            <h2>Parts {selectedCategory ? `for ${selectedCategory}` : ''}</h2>
+            <ul>
+              {parts.map(part => (
+                <li key={part.id}>
+                  <button onClick={() => loadPartDetail(part.id)}>
+                    {part.id}
+                    {part.name ? ` - ${part.name}` : ''}
+                  </button>
+                </li>
+              ))}
+            </ul>
+          </div>
         </div>
-      </div>
+      )}
     </div>
   );
 }

--- a/kicad_api.go
+++ b/kicad_api.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/samber/lo"
@@ -37,6 +38,19 @@ type KiCadPartDetail struct {
 	SymbolIDStr    string                    `json:"symbolIdStr,omitempty"`
 	ExcludeFromBOM string                    `json:"exclude_from_bom,omitempty"`
 	Fields         map[string]KiCadPartField `json:"fields,omitempty"`
+	Revision       string                    `json:"revision,omitempty"`
+}
+
+// PartSource represents a manufacturer/MPN pair for a part
+type PartSource struct {
+	Manufacturer string `json:"manufacturer"`
+	MPN          string `json:"mpn"`
+}
+
+// PartUpdateRequest captures fields that can be updated for a part
+type PartUpdateRequest struct {
+	Description string       `json:"description"`
+	Sources     []PartSource `json:"sources"`
 }
 
 // KiCadPartField represents a field in a KiCad part
@@ -149,12 +163,48 @@ func (s *KiCadServer) findColumnIndex(file *CSVFile, columnName string) int {
 	return -1
 }
 
+// findPart locates a part by IPN and returns its file and row index
+func (s *KiCadServer) findPart(partID string) (*CSVFile, int) {
+	for _, file := range s.csvCollection.Files {
+		ipnIdx := s.findColumnIndex(file, "IPN")
+		for i, row := range file.Rows {
+			if ipnIdx >= 0 && len(row) > ipnIdx && row[ipnIdx] == partID {
+				return file, i
+			}
+		}
+	}
+	return nil, -1
+}
+
+// ensureColumn makes sure a column exists in the file and returns its index
+func (s *KiCadServer) ensureColumn(file *CSVFile, header string) int {
+	idx := s.findColumnIndex(file, header)
+	if idx == -1 {
+		file.Headers = append(file.Headers, header)
+		idx = len(file.Headers) - 1
+		for i, row := range file.Rows {
+			file.Rows[i] = append(row, "")
+		}
+	}
+	return idx
+}
+
 // extractCategory extracts the CCC component from an IPN
 func (s *KiCadServer) extractCategory(ipnStr string) string {
 	// IPN format: CCC-NNN-VVVV
 	re := regexp.MustCompile(`^([A-Z][A-Z][A-Z])-(\d\d\d)-(\d\d\d\d)$`)
 	matches := re.FindStringSubmatch(ipnStr)
 	if len(matches) >= 2 {
+		return matches[1]
+	}
+	return ""
+}
+
+// extractRevision extracts the revision (VVVV) component from an IPN
+func (s *KiCadServer) extractRevision(ipnStr string) string {
+	re := regexp.MustCompile(`^[A-Z]{3}-\d{3}-(\d{4})$`)
+	matches := re.FindStringSubmatch(ipnStr)
+	if len(matches) == 2 {
 		return matches[1]
 	}
 	return ""
@@ -341,12 +391,91 @@ func (s *KiCadServer) getPartDetail(partID string) *KiCadPartDetail {
 					SymbolIDStr:    s.getSymbolIDFromCategory(category),
 					ExcludeFromBOM: "false", // Default to include in BOM
 					Fields:         fields,
+					Revision:       s.extractRevision(partID),
 				}
 			}
 		}
 	}
 
 	return nil
+}
+
+// updatePart updates editable fields for a part and saves to disk
+func (s *KiCadServer) updatePart(partID string, req PartUpdateRequest) error {
+	file, rowIdx := s.findPart(partID)
+	if file == nil {
+		return fmt.Errorf("part not found")
+	}
+	row := file.Rows[rowIdx]
+	if len(row) < len(file.Headers) {
+		padded := make([]string, len(file.Headers))
+		copy(padded, row)
+		row = padded
+		file.Rows[rowIdx] = row
+	}
+
+	if req.Description != "" {
+		descIdx := s.ensureColumn(file, "Description")
+		file.Rows[rowIdx][descIdx] = req.Description
+	}
+
+	for i, src := range req.Sources {
+		mfrHeader := "Manufacturer"
+		mpnHeader := "MPN"
+		if i > 0 {
+			idx := i + 1
+			mfrHeader = fmt.Sprintf("Manufacturer%d", idx)
+			mpnHeader = fmt.Sprintf("MPN%d", idx)
+		}
+		mfrIdx := s.ensureColumn(file, mfrHeader)
+		mpnIdx := s.ensureColumn(file, mpnHeader)
+		file.Rows[rowIdx][mfrIdx] = src.Manufacturer
+		file.Rows[rowIdx][mpnIdx] = src.MPN
+	}
+
+	if err := saveCSVFile(file); err != nil {
+		return err
+	}
+	return s.loadCSVCollection()
+}
+
+// startNewRevision creates a new part revision and returns its details
+func (s *KiCadServer) startNewRevision(partID string) (*KiCadPartDetail, error) {
+	file, rowIdx := s.findPart(partID)
+	if file == nil {
+		return nil, fmt.Errorf("part not found")
+	}
+
+	ipnIdx := s.findColumnIndex(file, "IPN")
+	if ipnIdx < 0 {
+		return nil, fmt.Errorf("IPN column missing")
+	}
+
+	row := file.Rows[rowIdx]
+	parts := strings.Split(row[ipnIdx], "-")
+	if len(parts) != 3 {
+		return nil, fmt.Errorf("invalid IPN format")
+	}
+	rev, err := strconv.Atoi(parts[2])
+	if err != nil {
+		return nil, fmt.Errorf("invalid revision")
+	}
+	rev++
+	parts[2] = fmt.Sprintf("%04d", rev)
+	newIPN := strings.Join(parts, "-")
+
+	newRow := make([]string, len(file.Headers))
+	copy(newRow, row)
+	newRow[ipnIdx] = newIPN
+	file.Rows = append(file.Rows, newRow)
+
+	if err := saveCSVFile(file); err != nil {
+		return nil, err
+	}
+	if err := s.loadCSVCollection(); err != nil {
+		return nil, err
+	}
+	return s.getPartDetail(newIPN), nil
 }
 
 // getSymbolIDFromCategory generates a symbol ID based on category
@@ -433,7 +562,16 @@ func (s *KiCadServer) partsByCategoryHandler(w http.ResponseWriter, r *http.Requ
 	_ = json.NewEncoder(w).Encode(parts)
 }
 
-// partDetailHandler handles the part detail endpoint
+// partsRouter routes part detail and revision endpoints
+func (s *KiCadServer) partsRouter(w http.ResponseWriter, r *http.Request) {
+	if strings.HasSuffix(r.URL.Path, "/revision") {
+		s.partRevisionHandler(w, r)
+		return
+	}
+	s.partDetailHandler(w, r)
+}
+
+// partDetailHandler handles GET/PUT for part details
 func (s *KiCadServer) partDetailHandler(w http.ResponseWriter, r *http.Request) {
 	if !s.authenticate(r) {
 		http.Error(w, "Unauthorized", http.StatusUnauthorized)
@@ -444,12 +582,54 @@ func (s *KiCadServer) partDetailHandler(w http.ResponseWriter, r *http.Request) 
 	path := strings.TrimPrefix(r.URL.Path, "/v1/parts/")
 	partID := strings.TrimSuffix(path, ".json")
 
-	part := s.getPartDetail(partID)
-	if part == nil {
-		http.Error(w, "Part not found", http.StatusNotFound)
+	switch r.Method {
+	case http.MethodGet:
+		part := s.getPartDetail(partID)
+		if part == nil {
+			http.Error(w, "Part not found", http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(part)
+	case http.MethodPut:
+		var req PartUpdateRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, "Bad request", http.StatusBadRequest)
+			return
+		}
+		if err := s.updatePart(partID, req); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		part := s.getPartDetail(partID)
+		if part == nil {
+			http.Error(w, "Part not found", http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(part)
+	default:
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+	}
+}
+
+// partRevisionHandler handles creating a new revision for a part
+func (s *KiCadServer) partRevisionHandler(w http.ResponseWriter, r *http.Request) {
+	if !s.authenticate(r) {
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
 		return
 	}
-
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	path := strings.TrimPrefix(r.URL.Path, "/v1/parts/")
+	partID := strings.TrimSuffix(path, "/revision")
+	part, err := s.startNewRevision(partID)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(part)
 }
@@ -484,7 +664,7 @@ func StartKiCadServer(pmDir, token string, port int) error {
 	http.HandleFunc("/v1/", server.rootHandler)
 	http.HandleFunc("/v1/categories.json", server.categoriesHandler)
 	http.HandleFunc("/v1/parts/category/", server.partsByCategoryHandler)
-	http.HandleFunc("/v1/parts/", server.partDetailHandler)
+	http.HandleFunc("/v1/parts/", server.partsRouter)
 
 	// Add a health check endpoint
 	http.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary
- add CSV save helper to persist part changes
- extend API with endpoints to edit part fields and create new revisions
- build React screen for editing a part including sources and revision controls

## Testing
- `go test ./...`
- `npm test --prefix frontend`


------
https://chatgpt.com/codex/tasks/task_e_689587bdb30c8326990b0afe165196fa