### PR TITLE
Handle missing CSVs by generating blank partmaster

### DIFF
--- a/kicad_api.go
+++ b/kicad_api.go
@@ -81,7 +81,12 @@ func (s *KiCadServer) loadCSVCollection() error {
 
 	collection, err := loadAllCSVFiles(s.pmDir)
 	if err != nil {
-		return fmt.Errorf("failed to load CSV files from %s: %w", s.pmDir, err)
+		// If loading fails, create a blank partmaster so the server can start
+		csvFile, err2 := createBlankPartmasterCSV(s.pmDir)
+		if err2 != nil {
+			return fmt.Errorf("failed to load CSV files from %s: %w", s.pmDir, err)
+		}
+		collection = &CSVFileCollection{Files: []*CSVFile{csvFile}}
 	}
 
 	s.csvCollection = collection

--- a/partmaster.go
+++ b/partmaster.go
@@ -109,6 +109,14 @@ func loadPartmasterFromDir(dir string) (partmaster, error) {
 		return pm, fmt.Errorf("error finding CSV files in directory %s: %v", dir, err)
 	}
 
+	if len(files) == 0 {
+		_, err := createBlankPartmasterCSV(dir)
+		if err != nil {
+			return pm, err
+		}
+		files = []string{filepath.Join(dir, "partmaster.csv")}
+	}
+
 	for _, file := range files {
 		var temp partmaster
 		err := loadCSV(file, &temp)


### PR DESCRIPTION
## Summary
- Generate a blank `partmaster.csv` with standard headers when no CSV files are present
- Ensure partmaster loading creates the empty file so the app can run without examples
- Fall back to creating a blank partmaster if CSV loading fails at server startup

## Testing
- `go test ./...`
- `go run . -http -pmDir /workspace/temp -port 8081`

------
https://chatgpt.com/codex/tasks/task_e_6895877e68e88326b35fb70f453b1319