### PR TITLE
Handle missing CSVs by generating blank partmaster

### DIFF
--- a/csv_data.go
+++ b/csv_data.go
@@ -40,7 +40,7 @@ func loadCSVRaw(filePath string) (*CSVFile, error) {
 	if err != nil {
 		return nil, fmt.Errorf("error reading headers from %s: %v", filePath, err)
 	}
-	
+
 	// Trim whitespace from headers
 	for i := range headers {
 		headers[i] = strings.TrimSpace(headers[i])
@@ -72,6 +72,40 @@ func loadCSVRaw(filePath string) (*CSVFile, error) {
 	}, nil
 }
 
+// createBlankPartmasterCSV creates an empty partmaster.csv file with standard headers
+func createBlankPartmasterCSV(dir string) (*CSVFile, error) {
+	headers := []string{"IPN", "Description", "Footprint", "Value", "Manufacturer", "MPN", "Datasheet", "Priority", "Checked"}
+
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		tmpDir := os.TempDir()
+		fmt.Printf("Warning: could not create directory %s: %v; using %s instead\n", dir, err, tmpDir)
+		dir = tmpDir
+	}
+
+	path := filepath.Join(dir, "partmaster.csv")
+	file, err := os.Create(path)
+	if err != nil {
+		return nil, fmt.Errorf("error creating file %s: %v", path, err)
+	}
+	defer file.Close()
+
+	writer := csv.NewWriter(file)
+	if err := writer.Write(headers); err != nil {
+		return nil, fmt.Errorf("error writing headers to %s: %v", path, err)
+	}
+	writer.Flush()
+	if err := writer.Error(); err != nil {
+		return nil, fmt.Errorf("error finalizing file %s: %v", path, err)
+	}
+
+	return &CSVFile{
+		Name:    filepath.Base(path),
+		Path:    path,
+		Headers: headers,
+		Rows:    [][]string{},
+	}, nil
+}
+
 // loadAllCSVFiles loads all CSV files from a directory
 func loadAllCSVFiles(dir string) (*CSVFileCollection, error) {
 	collection := &CSVFileCollection{
@@ -81,6 +115,15 @@ func loadAllCSVFiles(dir string) (*CSVFileCollection, error) {
 	files, err := filepath.Glob(filepath.Join(dir, "*.csv"))
 	if err != nil {
 		return nil, fmt.Errorf("error finding CSV files in directory %s: %v", dir, err)
+	}
+
+	if len(files) == 0 {
+		csvFile, err := createBlankPartmasterCSV(dir)
+		if err != nil {
+			return nil, err
+		}
+		collection.Files = append(collection.Files, csvFile)
+		return collection, nil
 	}
 
 	for _, filePath := range files {
@@ -94,7 +137,11 @@ func loadAllCSVFiles(dir string) (*CSVFileCollection, error) {
 	}
 
 	if len(collection.Files) == 0 {
-		return nil, fmt.Errorf("no valid CSV files found in directory %s", dir)
+		csvFile, err := createBlankPartmasterCSV(dir)
+		if err != nil {
+			return nil, err
+		}
+		collection.Files = append(collection.Files, csvFile)
 	}
 
 	return collection, nil

--- a/kicad_api.go
+++ b/kicad_api.go
@@ -81,7 +81,12 @@ func (s *KiCadServer) loadCSVCollection() error {
 
 	collection, err := loadAllCSVFiles(s.pmDir)
 	if err != nil {
-		return fmt.Errorf("failed to load CSV files from %s: %w", s.pmDir, err)
+		// If loading fails, create a blank partmaster so the server can start
+		csvFile, err2 := createBlankPartmasterCSV(s.pmDir)
+		if err2 != nil {
+			return fmt.Errorf("failed to load CSV files from %s: %w", s.pmDir, err)
+		}
+		collection = &CSVFileCollection{Files: []*CSVFile{csvFile}}
 	}
 
 	s.csvCollection = collection

--- a/partmaster.go
+++ b/partmaster.go
@@ -109,6 +109,14 @@ func loadPartmasterFromDir(dir string) (partmaster, error) {
 		return pm, fmt.Errorf("error finding CSV files in directory %s: %v", dir, err)
 	}
 
+	if len(files) == 0 {
+		csvFile, err := createBlankPartmasterCSV(dir)
+		if err != nil {
+			return pm, err
+		}
+		files = []string{csvFile.Path}
+	}
+
 	for _, file := range files {
 		var temp partmaster
 		err := loadCSV(file, &temp)


### PR DESCRIPTION
## Summary
- Generate a blank `partmaster.csv` with standard headers when no CSV files are present
- Ensure partmaster loading creates the empty file so the app can run without examples
- Fall back to creating a blank partmaster if CSV loading fails at server startup
- Use a temporary directory if the specified CSV path cannot be created

## Testing
- `go test ./...`
- `go run . -http -pmDir /proc/temp -port 8081`

------
https://chatgpt.com/codex/tasks/task_e_6895877e68e88326b35fb70f453b1319